### PR TITLE
Use promises for validations. add binding option to promises

### DIFF
--- a/examples/js/todoApp.js
+++ b/examples/js/todoApp.js
@@ -136,15 +136,13 @@ example.views.form = pie.activeView.extend({
     // don't really submit it...
     e.preventDefault();
 
-    this.list.validateAll(function(bool) {
-      if(bool) {
-        // insert the item at the beginning.
-        var newItem = new pie.model({title: this.list.get('nextItem'), completed: false});
-        this.list.push(newItem);
+    this.list.validateAll.then(function(bool) {
+      // insert the item at the beginning.
+      var newItem = new pie.model({title: this.list.get('nextItem'), completed: false});
+      this.list.push(newItem);
 
-        // remove the nextItem attribute, updating the UI.
-        this.list.set('nextItem', '');
-      }
+      // remove the nextItem attribute, updating the UI.
+      this.list.set('nextItem', '');
     }.bind(this));
   },
 

--- a/spec/ajaxSpec.js
+++ b/spec/ajaxSpec.js
@@ -91,7 +91,7 @@ describe("pie.ajax", function() {
       jasmine.Ajax.uninstall();
     });
 
-    it("should not blow up if there is no csrf token in the dom", function() {
+    it("should not blow up if there is no csrf token in the dom", function(done) {
       var meta = document.querySelector('meta[name="csrf-token"]');
       if(meta) meta.parentNode.removeChild(meta);
 
@@ -100,49 +100,50 @@ describe("pie.ajax", function() {
       this.ajax.get({
         url: '/get-path',
         dataSuccess: doneFn
-      });
-
-      expect(doneFn).toHaveBeenCalledWith({'get' : 'response'});
+      }).complete(function(){
+        expect(doneFn).toHaveBeenCalledWith({'get' : 'response'});
+      }, done);
     });
 
-    it("should use the csrf token in the dom if it is present", function() {
+    it("should use the csrf token in the dom if it is present", function(done) {
       this.ajax.app.cache.set('csrfToken', undefined);
       var meta = pie.dom.createElement('<meta name="csrf-token" content="abcdefg" />'), request;
       document.querySelector('head').appendChild(meta);
 
-      this.ajax.get({ url: '/get-path' });
-
-      request = jasmine.Ajax.requests.mostRecent();
-      expect(request.requestHeaders['X-CSRF-Token']).toEqual('abcdefg');
+      this.ajax.get({ url: '/get-path' }).complete(function(){
+        request = jasmine.Ajax.requests.mostRecent();
+        expect(request.requestHeaders['X-CSRF-Token']).toEqual('abcdefg');
+      }, done);
     });
 
-    it("should set default options on the request", function() {
-      this.ajax.get({ url: '/get-path' });
+    it("should set default options on the request", function(done) {
+      this.ajax.get({ url: '/get-path' }).complete(function(){
 
-      var request = jasmine.Ajax.requests.mostRecent();
-      expect(request.requestHeaders['Accept']).toEqual('application/json');
-      expect(request.requestHeaders['Content-Type']).toEqual('application/json');
-      expect(request.method).toEqual('GET');
+        var request = jasmine.Ajax.requests.mostRecent();
+        expect(request.requestHeaders['Accept']).toEqual('application/json');
+        expect(request.requestHeaders['Content-Type']).toEqual('application/json');
+        expect(request.method).toEqual('GET');
+      }, done);
     });
 
-    it("should allow alternate formats to be sent", function() {
+    it("should allow alternate formats to be sent", function(done) {
       this.ajax.post({
         url: '/post-path-html',
         accept: 'text/html',
         data: "foo=bar&baz=qux",
         csrfToken: 'xyz',
         verb: 'POST'
-      });
-
-      var request = jasmine.Ajax.requests.mostRecent();
-      expect(request.requestHeaders['Accept']).toEqual('text/html');
-      expect(request.requestHeaders['Content-Type']).toEqual('application/x-www-form-urlencoded');
-      expect(request.method).toEqual('POST');
-      expect(request.params).toEqual('foo=bar&baz=qux');
-      expect(request.data).toEqual('<span>foo</span>');
+      }).complete(function(){
+        var request = jasmine.Ajax.requests.mostRecent();
+        expect(request.requestHeaders['Accept']).toEqual('text/html');
+        expect(request.requestHeaders['Content-Type']).toEqual('application/x-www-form-urlencoded');
+        expect(request.method).toEqual('POST');
+        expect(request.params).toEqual('foo=bar&baz=qux');
+        expect(request.data).toEqual('<span>foo</span>');
+      }, done);
     });
 
-    it("should allow a promise-style request to be conducted", function() {
+    it("should allow a promise-style request to be conducted", function(done) {
       var response, xhr, request = this.ajax.get('/get-path');
 
       request.dataSuccess(function(d) {
@@ -153,8 +154,10 @@ describe("pie.ajax", function() {
         xhr = x;
       });
 
-      expect(response).toEqual({get: 'response'});
-      expect(xhr).toEqual(request.xhr);
+      request.complete(function() {
+        expect(response).toEqual({get: 'response'});
+        expect(xhr).toEqual(request.xhr);
+      }, done);
     });
 
   });

--- a/src/ajaxRequest.js
+++ b/src/ajaxRequest.js
@@ -81,7 +81,7 @@ pie.ajaxRequest = pie.model.extend('ajaxRequest', {
     // upcase before we validate inclusion.
     if(this.get('verb')) this.set('verb', this.get('verb').toUpperCase());
 
-    return this.validateAll().bind(this).catch(function(){
+    return this.validateAll().catch(function(){
       throw new Error(JSON.stringify(this.get('validationErrors')));
     });
   },

--- a/src/formView.js
+++ b/src/formView.js
@@ -217,7 +217,7 @@ pie.formView = pie.activeView.extend('formView', pie.mixins.bindings, {
   // By default, `model.validateAll` will be invoked but this can be overridden
   // to talk to external services, etc.
   validateModel: function(cb) {
-    this.model.validateAll(cb);
+    this.model.validateAll().then(cb);
   },
 
   // ** pie.formView.validateAndSubmitForm **

--- a/src/promise.js
+++ b/src/promise.js
@@ -7,6 +7,7 @@ pie.promise = pie.base.extend({
     this.resolves = [];
     this.rejects  = [];
 
+    this.ctxt     = undefined;
     this.result   = undefined;
     this.state    = 'UNFULFILLED';
 
@@ -21,8 +22,14 @@ pie.promise = pie.base.extend({
     }
   },
 
+  bind: function(ctxt) {
+    this.ctxt = ctxt;
+    return this;
+  },
+
   then: function(onResolve, onReject) {
     var child = this.__class.create();
+    child.bind(this.ctxt);
 
     this.resolves.push([onResolve, child]);
     this.rejects.push([onReject, child]);
@@ -63,6 +70,14 @@ pie.promise = pie.base.extend({
       callback = tuple[0];
       promise = tuple[1];
       result = this.result;
+
+      if(promise.ctxt) {
+        if(pie.object.isString(callback)) {
+          callback = promise.ctxt[callback].bind(promise.ctxt);
+        } else if (pie.object.isFunction(callback)) {
+          callback = callback.bind(promise.ctxt);
+        }
+      }
 
       if(pie.object.isFunction(callback)) {
         try {

--- a/src/validator.js
+++ b/src/validator.js
@@ -253,7 +253,8 @@ pie.validator = pie.base.extend('validator', {
   // **pie.validator.fn**
   //
   // A generic function interface. This enables a function to be passed,
-  // along with all the normal options.
+  // along with all the normal options. Asynchronous functions should return
+  // a promise.
   // ```
   // var opts = {fn: function(v){ return v.length === 3; }};
   // validator.fn("foo", opts);
@@ -261,9 +262,9 @@ pie.validator = pie.base.extend('validator', {
   // validator.fn("foos", opts);
   // //=> false
   // ```
-  fn: function(value, options, cb) {
+  fn: function(value, options) {
     return this.withStandardChecks(value, options, function(){
-      return options.fn.call(null, value, options, cb);
+      return options.fn.call(null, value, options);
     });
   },
 


### PR DESCRIPTION
```js
// validateAll is just a pie.promise.all usage.
model.validateAll().then('submitToServer').catch('handleFailure');

// strings can be provided as validation callbacks since validation promises are bound to the model.
model.validate('foo').then('submitToServer');

// in general, strings can be provided if a binding is setup on the promise.
pie.promise.resolve('foo').bind(this).then('bar').catch('baz');
```