### PR TITLE
Enable live dom references in activeViews

### DIFF
--- a/docs/annotated/pie.html
+++ b/docs/annotated/pie.html
@@ -7675,6 +7675,7 @@ pie.activeView = pie.view.extend(<span class="hljs-string">'activeView'</span>, 
   init: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(options)</span> </span>{
     <span class="hljs-keyword">if</span>(pie.object.isString(options)) options = {template: options};
     <span class="hljs-keyword">this</span>._super(options);
+    <span class="hljs-keyword">this</span>.refs = {};
   },
 
   setup: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
@@ -7686,6 +7687,11 @@ pie.activeView = pie.view.extend(<span class="hljs-string">'activeView'</span>, 
 
     <span class="hljs-keyword">if</span>(<span class="hljs-keyword">this</span>.options.renderOnSetup || <span class="hljs-keyword">this</span>.options.renderOnSetup === <span class="hljs-literal">undefined</span>) {
       <span class="hljs-keyword">this</span>.eonce(<span class="hljs-string">'setup'</span>, <span class="hljs-keyword">this</span>.render.bind(<span class="hljs-keyword">this</span>));
+    }
+
+    <span class="hljs-keyword">if</span>(<span class="hljs-keyword">this</span>.options.refs) {
+      <span class="hljs-keyword">this</span>.setupRefs();
+      <span class="hljs-keyword">this</span>.on(<span class="hljs-string">'afterRender'</span>, <span class="hljs-string">'clearRefCache'</span>);
     }
 
     <span class="hljs-keyword">this</span>.eon(<span class="hljs-string">'render'</span>, <span class="hljs-keyword">this</span>._renderTemplateToEl.bind(<span class="hljs-keyword">this</span>));
@@ -7845,6 +7851,41 @@ There’s the possibility that a template needs to be fetched from a remote sour
 
   templateName: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
     <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>.options.template;
+  },
+
+  setupRefs: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
+    <span class="hljs-keyword">var</span> refs = {};
+    <span class="hljs-keyword">var</span> self = <span class="hljs-keyword">this</span>;
+
+    <span class="hljs-built_in">Object</span>.defineProperty(refs, <span class="hljs-string">'_cache'</span>, {
+      iteratable: <span class="hljs-literal">false</span>,
+      writable: <span class="hljs-literal">true</span>
+    });
+
+    refs.fetch = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(name)</span></span>{
+      <span class="hljs-keyword">delete</span> refs._cache[name];
+      <span class="hljs-keyword">return</span> refs[name];
+    };
+
+    refs._cache = {};
+
+    pie.object.forEach(self.options.refs, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(k,v)</span> </span>{
+
+      <span class="hljs-built_in">Object</span>.defineProperty(refs, k, {
+        iteratable: <span class="hljs-literal">false</span>,
+        get: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
+          <span class="hljs-keyword">if</span>(pie.object.has(refs._cache, k)) <span class="hljs-keyword">return</span> refs._cache[k];
+          <span class="hljs-keyword">return</span> refs._cache[k] = self.qs(v);
+        }
+      });
+
+    });
+
+    self[self.options.refsName || <span class="hljs-string">'dom'</span>] = refs;
+  },
+
+  clearRefCache: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
+    <span class="hljs-keyword">this</span>[<span class="hljs-keyword">this</span>.options.refsName || <span class="hljs-string">'dom'</span>]._cache = {};
   }
 
 });


### PR DESCRIPTION
OMG typing sux.

```js
myView = pie.activeView.extend({
  init: function() {
    this._super({
      refs: {
        listContainer: '.js-list-container',
        addItemBtn: '.js-add-item-btn'
      }
    },

   someHandler: function() {
     this.dom.addItemBtn.disabled = this.isFoo();
   },

  someOtherHandler: function() {
    var el = this.dom.fetch('addItemBtn')
    if(el) el.parentNode.removeChild(el);
  }
});
```